### PR TITLE
feat: Use type specific transformations instead of JSON.stringify

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ web-storage attempts to follow the recommendations but do not follow the rules s
 web-storage is created with the ideas to provide the following:
 
 1. Provide a common public API for accessing different storage types that expose different APIs
-2. Encapsulate complexity of accessing storage like IndexedDB or CacheAPI that is asynchronous in nature and requires more complex code for access.
+2. Encapsulate code that is required to access or manipulate data from the storage like:
+   1. Handle asynchronous code in accessing storage like IndexedDB or CacheAPI
+   2. Provide data transformation for accessing storage like LocalStorage and SessionStorage that requires the value to be store as strings.
 3. Allow integration with other javascript code that provide functionality outside of web storage. An example is web-storage-react a library that is created to provide web storage functionality to ReactJs applications.
 4. Have a public API that is generic while being extensible for the individual web storage types that provide more complex functionality like querying for IndexedDB or manipulating binary objects like CacheAPI.
 5. Handle transformation of data types for storage type like localStorage that only manipulate values in strings

--- a/src/storageReducer/README.md
+++ b/src/storageReducer/README.md
@@ -27,15 +27,18 @@ The other observation is that the interface declares the value returned by getIt
 
 ### Message options
 
-| Property | Description                                                                                                                                                                                                                                                                                                                                                                                        |
-| -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `type`   | Indicates the type of operation to be performed **_*(Required)*_** <br /> Supports :<ul><li>get</li><li>set</li><li>remove</li><li>clear</li></ul>                                                                                                                                                                                                                                                 |
-| `key`    | String value indicating the identifier of the value in the storage to be manipulated.                                                                                                                                                                                                                                                                                                              |
-| `value`  | Represents the value that is stored in the storage. localStorageReducer applies `JSON.stringify` on the value when setting values and `JSON.parse` when getting values. <br /> Supports javascript datatypes <ul><li>number</li><li>string</li><li>boolean</li><li>object</li><li>array</li><li>null</li></ul><br /> Unsupported javascript datatypes <ul><li>function</li><li>undefined</li></ul> |
+| Property   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `type`     | Indicates the type of operation to be performed **_*(Required)*_** <br /> Supports :<ul><li>get</li><li>set</li><li>remove</li><li>clear</li></ul>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `key`      | String value indicating the identifier of the value in the storage to be manipulated.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `value`    | Represents the value that is stored in the storage. localStorageReducer transforms the value when retrieving and storing in the storage. The transformation applied depends on the supplied `type`, `datatype` or `value`. <br /> Supports javascript datatypes <ul><li>number</li><li>string</li><li>boolean</li><li>date</li><li>object</li><li>array</li></ul><br /> Unsupported javascript datatypes <ul><li>function</li><li>undefined</li><li>null</li><li>NaN</li></ul>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `datatype` | Type of the value to be manipulated. Used by `type`: `get` or `type`: `set` to convert between string values and typed values. If value is not supplied the datatype will default to `string` for `type`: `get` and for `type`: `set` the type will be best guess using javascripts' `typeof` and `instanceof` commands. The following are the accepted values: <ul><li>string<br />- transform for set: (value) => value.toString()<br />- transform for get: NA</li><li>boolean<br />- transform for set: (value) => value.toString()<br />- transform for get: transform for get: (value) => value === "true"</li> <li>date<br />- transform for set: (value) => value.toISOString()<br />- transform for get: value => new Date(value)</li><li>number<br />- transform for set: (value) => value.toString()<br />- transform for get: (value) => Number(value)</li><li>array<br />- transform for set: (value) => JSON.stringify(value)<br />- transform for get: (value) => JSON.parse(value)</li><li>object<br />- transform for set: (value) => JSON.stringify(value)<br />- transform for get: (value) => JSON.parse(value)</li></ul> |
 
 #### Example usage
 
 ##### Get a value
+
+The message type `get` will retrieve a value from the storage that is identified by the key. It returns null if the key is not found. This message type will perform conversion from the underlying storage type which is a `string` to the type defined in the message `datatype` property. By default, the datatype is set to `string` which will return the value from the storage without conversion. The consumer needs to handle errors if the requested datatype does not match the value stored.
 
 ###### local storage
 
@@ -45,6 +48,16 @@ import { storageReducer } from "@unwall/web-storage";
 const value = storageReducer(window.localStorage, {
   type: "get",
   key: "key"
+});
+```
+
+```js
+import { storageReducer } from "@unwall/web-storage";
+
+const value = storageReducer(window.localStorage, {
+  type: "get",
+  key: "key",
+  datatype: "array"
 });
 ```
 
@@ -59,7 +72,19 @@ const value = storageReducer(window.sessionStorage, {
 });
 ```
 
+```js
+import { storageReducer } from "@unwall/web-storage";
+
+const value = storageReducer(window.sessionStorage, {
+  type: "get",
+  key: "key",
+  datatype: "date"
+});
+```
+
 ##### Set a value
+
+The message type `set` will set a value in the storage that is identified by the key. This message type will perform conversion from the type defined in the message `datatype` property to the underlying storage type which is a `string`. If not supplied the datatype will be obtained from the value using `typeof value`. The consumer needs to handle errors if the requested datatype does not match the value stored. Setting the value of an existing `key` in the storage will override the existing value.
 
 ###### local storage
 
@@ -70,6 +95,17 @@ storageReducer(window.localStorage, {
   type: "set",
   key: "key",
   value: "value"
+});
+```
+
+```js
+import { storageReducer } from "@unwall/web-storage";
+
+storageReducer(window.localStorage, {
+  type: "set",
+  key: "key",
+  value: "Thu Jan 16 2020 22:37:19 GMT-0500 (Eastern Standard Time)",
+  datatype: "date"
 });
 ```
 
@@ -85,7 +121,20 @@ storageReducer(window.sessionStorage, {
 });
 ```
 
+```js
+import { storageReducer } from "@unwall/web-storage";
+
+storageReducer(window.sessionStorage, {
+  type: "set",
+  key: "key",
+  value: "{}",
+  datatype: "object"
+});
+```
+
 ##### Remove a value
+
+The message type `remove` will remove a value in the storage that is identified by the key. If the key provided is not found in the storage, it will just return with no action performed.
 
 ###### local storage
 
@@ -110,6 +159,8 @@ const value = storageReducer(window.sessionStorage, {
 ```
 
 ##### Clear all values
+
+The message type `clear` will remove all value in the storage. If the storage is empty, it will just return with no action performed. This action will also remove all values in the storage that is not set using `@unwall/web-storage`
 
 ###### local storage
 

--- a/src/storageReducer/index.js
+++ b/src/storageReducer/index.js
@@ -1,20 +1,63 @@
 const getItem = (state, action) => {
-  const value = state.getItem(action.key);
-  return JSON.parse(value);
+  const { key, datatype } = action;
+  const value = state.getItem(key);
+  switch (datatype) {
+    case "boolean": {
+      return Boolean(value);
+    }
+    case "date": {
+      return new Date(value);
+    }
+    case "number": {
+      return Number(value);
+    }
+    case "array":
+    case "object": {
+      return JSON.parse(value);
+    }
+  }
+  return value;
 };
 
 const setItem = (state, action) => {
   const { key, value } = action;
-  const type = typeof value;
-  switch (type) {
-    case "function":
-    case "undefined": {
-      throw new Error(
-        "setItem does not accept values of type undefined or function"
-      );
+  let { datatype } = action;
+  if (!("datatype" in action)) {
+    // when data type is not provided use value inspection to determine the datatype.
+    let type = typeof value;
+    if (type === "undefined" || type == "function" || value === null) {
+      throw new Error(`setItem does not support value: ${value}`);
     }
-    default:
+
+    if (type === "object") {
+      if (value instanceof Array) {
+        type = "array";
+      } else if (value instanceof Date) {
+        type = "date";
+      }
+    }
+    datatype = type;
+  }
+
+  switch (datatype) {
+    case "boolean":
+    case "number":
+    case "string": {
+      state.setItem(key, value.toString());
+      break;
+    }
+    case "date": {
+      state.setItem(key, value.toISOString());
+      break;
+    }
+    case "array":
+    case "object": {
       state.setItem(key, JSON.stringify(value));
+      break;
+    }
+    default: {
+      throw new Error(`setItem does support datatype: ${datatype}`);
+    }
   }
 };
 

--- a/src/storageReducer/index.spec.js
+++ b/src/storageReducer/index.spec.js
@@ -13,49 +13,11 @@ describe.each([
   describe(`${name}`, () => {
     beforeEach(() => initializeStorage(storage));
 
-    it("should allow state.setItem with integer", () => {
-      const key = "testKey";
-      const value = 10;
-      const expectedKey = key;
-      const expectedValue = JSON.stringify(value);
-
-      const action = { type: "set", key, value };
-
-      reducer(storage, action);
-
-      expect(storage.setItem).toHaveBeenCalledTimes(1);
-      expect(storage.setItem).toHaveBeenLastCalledWith(
-        expectedKey,
-        expectedValue
-      );
-      expect(storage.__STORE__[expectedKey]).toEqual(expectedValue);
-      expect(Object.keys(storage.__STORE__).length).toEqual(1);
-    });
-
-    it("should allow state.setItem with decimal", () => {
-      const key = "testKey";
-      const value = 10.0;
-      const expectedKey = key;
-      const expectedValue = JSON.stringify(value);
-
-      const action = { type: "set", key, value };
-
-      reducer(storage, action);
-
-      expect(storage.setItem).toHaveBeenCalledTimes(1);
-      expect(storage.setItem).toHaveBeenLastCalledWith(
-        expectedKey,
-        expectedValue
-      );
-      expect(storage.__STORE__[expectedKey]).toEqual(expectedValue);
-      expect(Object.keys(storage.__STORE__).length).toEqual(1);
-    });
-
-    it("should allow state.setItem with string", () => {
+    it("should allow state.setItem with no datatype for string", () => {
       const key = "testKey";
       const value = "10.0";
       const expectedKey = key;
-      const expectedValue = JSON.stringify(value);
+      const expectedValue = value.toString();
 
       const action = { type: "set", key, value };
 
@@ -70,7 +32,183 @@ describe.each([
       expect(Object.keys(storage.__STORE__).length).toEqual(1);
     });
 
-    it("should allow state.setItem with object", () => {
+    it("should allow state.setItem with datatype string for string", () => {
+      const key = "testKey";
+      const value = "10.0";
+      const datatype = "string";
+      const expectedKey = key;
+      const expectedValue = value.toString();
+
+      const action = { type: "set", key, value, datatype };
+
+      reducer(storage, action);
+
+      expect(storage.setItem).toHaveBeenCalledTimes(1);
+      expect(storage.setItem).toHaveBeenLastCalledWith(
+        expectedKey,
+        expectedValue
+      );
+      expect(storage.__STORE__[expectedKey]).toEqual(expectedValue);
+      expect(Object.keys(storage.__STORE__).length).toEqual(1);
+    });
+
+    it("should allow state.setItem with no datatype for boolean", () => {
+      const key = "testKey";
+      const value = true;
+      const expectedKey = key;
+      const expectedValue = value.toString();
+
+      const action = { type: "set", key, value };
+
+      reducer(storage, action);
+
+      expect(storage.setItem).toHaveBeenCalledTimes(1);
+      expect(storage.setItem).toHaveBeenLastCalledWith(
+        expectedKey,
+        expectedValue
+      );
+      expect(storage.__STORE__[expectedKey]).toEqual(expectedValue);
+      expect(Object.keys(storage.__STORE__).length).toEqual(1);
+    });
+
+    it("should allow state.setItem with datatype number for boolean", () => {
+      const key = "testKey";
+      const value = true;
+      const datatype = "boolean";
+      const expectedKey = key;
+      const expectedValue = value.toString();
+
+      const action = { type: "set", key, value, datatype };
+
+      reducer(storage, action);
+
+      expect(storage.setItem).toHaveBeenCalledTimes(1);
+      expect(storage.setItem).toHaveBeenLastCalledWith(
+        expectedKey,
+        expectedValue
+      );
+      expect(storage.__STORE__[expectedKey]).toEqual(expectedValue);
+      expect(Object.keys(storage.__STORE__).length).toEqual(1);
+    });
+
+    it("should allow state.setItem with no datatype for integer", () => {
+      const key = "testKey";
+      const value = 10;
+      const expectedKey = key;
+      const expectedValue = value.toString();
+
+      const action = { type: "set", key, value };
+
+      reducer(storage, action);
+
+      expect(storage.setItem).toHaveBeenCalledTimes(1);
+      expect(storage.setItem).toHaveBeenLastCalledWith(
+        expectedKey,
+        expectedValue
+      );
+      expect(storage.__STORE__[expectedKey]).toEqual(expectedValue);
+      expect(Object.keys(storage.__STORE__).length).toEqual(1);
+    });
+
+    it("should allow state.setItem with datatype number for integer", () => {
+      const key = "testKey";
+      const value = 10;
+      const datatype = "number";
+      const expectedKey = key;
+      const expectedValue = value.toString();
+
+      const action = { type: "set", key, value, datatype };
+
+      reducer(storage, action);
+
+      expect(storage.setItem).toHaveBeenCalledTimes(1);
+      expect(storage.setItem).toHaveBeenLastCalledWith(
+        expectedKey,
+        expectedValue
+      );
+      expect(storage.__STORE__[expectedKey]).toEqual(expectedValue);
+      expect(Object.keys(storage.__STORE__).length).toEqual(1);
+    });
+
+    it("should allow state.setItem with no datatype for decimal", () => {
+      const key = "testKey";
+      const value = 10.0;
+      const expectedKey = key;
+      const expectedValue = value.toString();
+
+      const action = { type: "set", key, value };
+
+      reducer(storage, action);
+
+      expect(storage.setItem).toHaveBeenCalledTimes(1);
+      expect(storage.setItem).toHaveBeenLastCalledWith(
+        expectedKey,
+        expectedValue
+      );
+      expect(storage.__STORE__[expectedKey]).toEqual(expectedValue);
+      expect(Object.keys(storage.__STORE__).length).toEqual(1);
+    });
+
+    it("should allow state.setItem with datatype number for decimal", () => {
+      const key = "testKey";
+      const value = 10.0;
+      const datatype = "number";
+      const expectedKey = key;
+      const expectedValue = value.toString();
+
+      const action = { type: "set", key, value, datatype };
+
+      reducer(storage, action);
+
+      expect(storage.setItem).toHaveBeenCalledTimes(1);
+      expect(storage.setItem).toHaveBeenLastCalledWith(
+        expectedKey,
+        expectedValue
+      );
+      expect(storage.__STORE__[expectedKey]).toEqual(expectedValue);
+      expect(Object.keys(storage.__STORE__).length).toEqual(1);
+    });
+
+    it("should allow state.setItem with no datatype for date", () => {
+      const key = "testKey";
+      const value = new Date();
+      const expectedKey = key;
+      const expectedValue = value.toISOString();
+
+      const action = { type: "set", key, value };
+
+      reducer(storage, action);
+
+      expect(storage.setItem).toHaveBeenCalledTimes(1);
+      expect(storage.setItem).toHaveBeenLastCalledWith(
+        expectedKey,
+        expectedValue
+      );
+      expect(storage.__STORE__[expectedKey]).toEqual(expectedValue);
+      expect(Object.keys(storage.__STORE__).length).toEqual(1);
+    });
+
+    it("should allow state.setItem with datatype date for date", () => {
+      const key = "testKey";
+      const value = new Date();
+      const datatype = "date";
+      const expectedKey = key;
+      const expectedValue = value.toISOString();
+
+      const action = { type: "set", key, value, datatype };
+
+      reducer(storage, action);
+
+      expect(storage.setItem).toHaveBeenCalledTimes(1);
+      expect(storage.setItem).toHaveBeenLastCalledWith(
+        expectedKey,
+        expectedValue
+      );
+      expect(storage.__STORE__[expectedKey]).toEqual(expectedValue);
+      expect(Object.keys(storage.__STORE__).length).toEqual(1);
+    });
+
+    it("should allow state.setItem with no datatype for object", () => {
       const key = "testKey";
       const value = { a: 10.0 };
       const expectedKey = key;
@@ -89,7 +227,27 @@ describe.each([
       expect(Object.keys(storage.__STORE__).length).toEqual(1);
     });
 
-    it("should allow state.setItem with array", () => {
+    it("should allow state.setItem with datatype object for object", () => {
+      const key = "testKey";
+      const value = { a: 10.0 };
+      const datatype = "object";
+      const expectedKey = key;
+      const expectedValue = JSON.stringify(value);
+
+      const action = { type: "set", key, value, datatype };
+
+      reducer(storage, action);
+
+      expect(storage.setItem).toHaveBeenCalledTimes(1);
+      expect(storage.setItem).toHaveBeenLastCalledWith(
+        expectedKey,
+        expectedValue
+      );
+      expect(storage.__STORE__[expectedKey]).toEqual(expectedValue);
+      expect(Object.keys(storage.__STORE__).length).toEqual(1);
+    });
+
+    it("should allow state.setItem with no datatype for array", () => {
       const key = "testKey";
       const value = [10.0, "a"];
       const expectedKey = key;
@@ -108,13 +266,14 @@ describe.each([
       expect(Object.keys(storage.__STORE__).length).toEqual(1);
     });
 
-    it("should allow state.setItem with null", () => {
+    it("should allow state.setItem with datatype array for array", () => {
       const key = "testKey";
-      const value = null;
-      const expectedKey = `${key}`;
+      const value = [10.0, "a"];
+      const datatype = "array";
+      const expectedKey = key;
       const expectedValue = JSON.stringify(value);
 
-      const action = { type: "set", key, value };
+      const action = { type: "set", key, value, datatype };
 
       reducer(storage, action);
 
@@ -127,95 +286,260 @@ describe.each([
       expect(Object.keys(storage.__STORE__).length).toEqual(1);
     });
 
-    it("should error out on state.setItem with undefined", () => {
+    it("should error out on state.setItem with value as null", () => {
+      const key = "testKey";
+      const value = null;
+
+      const action = { type: "set", key, value };
+
+      expect(() => reducer(storage, action)).toThrowError(
+        `setItem does not support value: ${value}`
+      );
+    });
+
+    it("should error out on state.setItem with value as undefined", () => {
       const key = "testKey";
       const value = undefined;
 
       const action = { type: "set", key, value };
 
       expect(() => reducer(storage, action)).toThrowError(
-        "setItem does not accept values of type undefined or function"
+        `setItem does not support value: ${value}`
       );
     });
 
-    it("should error out on state.setItem with function", () => {
+    it("should error out on state.setItem with value as function", () => {
       const key = "testKey";
       const value = function() {};
 
       const action = { type: "set", key, value };
 
       expect(() => reducer(storage, action)).toThrowError(
-        "setItem does not accept values of type undefined or function"
+        `setItem does not support value: ${value}`
       );
     });
 
-    it("should return integer value for state.getItem", () => {
+    describe.each([undefined, null, "", "  ", NaN, "invalid", "symbol"])(
+      "setItem invalid datatypes",
+      datatype => {
+        beforeEach(() => initializeStorage(storage));
+
+        it(`should error out for invalid datatype "${datatype}"`, () => {
+          const action = {
+            type: "set",
+            key: "testkey",
+            value: "testvalue",
+            datatype
+          };
+          expect(() => reducer(storage, action)).toThrowError(
+            new Error(`setItem does support datatype: ${datatype}`)
+          );
+        });
+      }
+    );
+
+    it("should return boolean value as string for state.getItem with no datatype", () => {
       const key = "testKey";
-      const expectedKey = key;
+      const value = "true";
+      const expectedValue = "true";
+      const action = { type: "get", key };
+      storage.getItem.mockReturnValueOnce(value);
+
+      const actualValue = reducer(storage, action);
+
+      expect(storage.getItem).toHaveBeenCalledTimes(1);
+      expect(storage.getItem).toHaveBeenLastCalledWith(key);
+      expect(actualValue).toEqual(expectedValue);
+    });
+
+    it("should return boolean value as boolean for state.getItem with datatype boolean", () => {
+      const key = "testKey";
+      const value = "true";
+      const datatype = "boolean";
+      const expectedValue = true;
+      const action = { type: "get", key, datatype };
+      storage.getItem.mockReturnValueOnce(value);
+
+      const actualValue = reducer(storage, action);
+
+      expect(storage.getItem).toHaveBeenCalledTimes(1);
+      expect(storage.getItem).toHaveBeenLastCalledWith(key);
+      expect(actualValue).toEqual(expectedValue);
+    });
+
+    it("should return date value as string for state.getItem with no datatype", () => {
+      const date = new Date();
+      const key = "testKey";
+      const value = date.toISOString();
+      const expectedValue = date.toISOString();
+      const action = { type: "get", key };
+      storage.getItem.mockReturnValueOnce(value);
+
+      const actualValue = reducer(storage, action);
+
+      expect(storage.getItem).toHaveBeenCalledTimes(1);
+      expect(storage.getItem).toHaveBeenLastCalledWith(key);
+      expect(actualValue).toEqual(expectedValue);
+    });
+
+    it("should return date value as date for state.getItem with datatype date", () => {
+      const date = new Date();
+      const key = "testKey";
+      const value = date.toISOString();
+      const datatype = "date";
+      const expectedValue = date;
+      const action = { type: "get", key, datatype };
+      storage.getItem.mockReturnValueOnce(value);
+
+      const actualValue = reducer(storage, action);
+
+      expect(storage.getItem).toHaveBeenCalledTimes(1);
+      expect(storage.getItem).toHaveBeenLastCalledWith(key);
+      expect(actualValue).toEqual(expectedValue);
+    });
+
+    it("should return integer value as string for state.getItem with no datatype", () => {
+      const key = "testKey";
+      const value = "10";
+      const expectedValue = "10";
+      const action = { type: "get", key };
+      storage.getItem.mockReturnValueOnce(value);
+
+      const actualValue = reducer(storage, action);
+
+      expect(storage.getItem).toHaveBeenCalledTimes(1);
+      expect(storage.getItem).toHaveBeenLastCalledWith(key);
+      expect(actualValue).toEqual(expectedValue);
+    });
+
+    it("should return integer value as number for state.getItem with datatype number", () => {
+      const key = "testKey";
+      const value = "10";
+      const datatype = "number";
       const expectedValue = 10;
-      const action = { type: "get", key };
-      storage.getItem.mockReturnValueOnce(JSON.stringify(expectedValue));
+      const action = { type: "get", key, datatype };
+      storage.getItem.mockReturnValueOnce(value);
 
       const actualValue = reducer(storage, action);
 
       expect(storage.getItem).toHaveBeenCalledTimes(1);
-      expect(storage.getItem).toHaveBeenLastCalledWith(expectedKey);
+      expect(storage.getItem).toHaveBeenLastCalledWith(key);
       expect(actualValue).toEqual(expectedValue);
     });
 
-    it("should return decimal value for state.getItem", () => {
+    it("should return decimal value as string for state.getItem with no datatype", () => {
       const key = "testKey";
-      const expectedKey = key;
-      const expectedValue = 10.0;
-      const action = { type: "get", key };
-      storage.getItem.mockReturnValueOnce(JSON.stringify(expectedValue));
-
-      const actualValue = reducer(storage, action);
-
-      expect(storage.getItem).toHaveBeenCalledTimes(1);
-      expect(storage.getItem).toHaveBeenLastCalledWith(expectedKey);
-      expect(actualValue).toEqual(expectedValue);
-    });
-
-    it("should return string value for state.getItem", () => {
-      const key = "testKey";
-      const expectedKey = key;
+      const value = "10.0";
       const expectedValue = "10.0";
       const action = { type: "get", key };
-      storage.getItem.mockReturnValueOnce(JSON.stringify(expectedValue));
+      storage.getItem.mockReturnValueOnce(value);
 
       const actualValue = reducer(storage, action);
 
       expect(storage.getItem).toHaveBeenCalledTimes(1);
-      expect(storage.getItem).toHaveBeenLastCalledWith(expectedKey);
+      expect(storage.getItem).toHaveBeenLastCalledWith(key);
       expect(actualValue).toEqual(expectedValue);
     });
 
-    it("should return object value for state.getItem", () => {
+    it("should return decimal value as number for state.getItem with datatype number", () => {
       const key = "testKey";
-      const expectedKey = key;
-      const expectedValue = { a: "10.0" };
+      const value = "10.0";
+      const datatype = "number";
+      const expectedValue = 10.0;
+      const action = { type: "get", key, datatype };
+      storage.getItem.mockReturnValueOnce(value);
+
+      const actualValue = reducer(storage, action);
+
+      expect(storage.getItem).toHaveBeenCalledTimes(1);
+      expect(storage.getItem).toHaveBeenLastCalledWith(key);
+      expect(actualValue).toEqual(expectedValue);
+    });
+
+    it("should return string value as string for state.getItem with no datatype", () => {
+      const key = "testKey";
+      const value = "10.0";
+      const expectedValue = "10.0";
       const action = { type: "get", key };
-      storage.getItem.mockReturnValueOnce(JSON.stringify(expectedValue));
+      storage.getItem.mockReturnValueOnce(value);
 
       const actualValue = reducer(storage, action);
 
       expect(storage.getItem).toHaveBeenCalledTimes(1);
-      expect(storage.getItem).toHaveBeenLastCalledWith(expectedKey);
+      expect(storage.getItem).toHaveBeenLastCalledWith(key);
       expect(actualValue).toEqual(expectedValue);
     });
 
-    it("should return array value for state.getItem", () => {
+    it("should return string value as string for state.getItem with datatype string", () => {
       const key = "testKey";
-      const expectedKey = key;
+      const value = "10.0";
+      const datatype = "string";
+      const expectedValue = "10.0";
+      const action = { type: "get", key, datatype };
+      storage.getItem.mockReturnValueOnce(value);
+
+      const actualValue = reducer(storage, action);
+
+      expect(storage.getItem).toHaveBeenCalledTimes(1);
+      expect(storage.getItem).toHaveBeenLastCalledWith(key);
+      expect(actualValue).toEqual(expectedValue);
+    });
+
+    it("should return array value as string for state.getItem with no datatype", () => {
+      const key = "testKey";
+      const value = JSON.stringify(["10.0", 10, 10.0]);
+      const expectedValue = JSON.stringify(["10.0", 10, 10.0]);
+      const action = { type: "get", key };
+      storage.getItem.mockReturnValueOnce(value);
+
+      const actualValue = reducer(storage, action);
+
+      expect(storage.getItem).toHaveBeenCalledTimes(1);
+      expect(storage.getItem).toHaveBeenLastCalledWith(key);
+      expect(actualValue).toEqual(expectedValue);
+    });
+
+    it("should return array value as array for state.getItem with datatype array", () => {
+      const key = "testKey";
+      const value = JSON.stringify(["10.0", 10, 10.0]);
+      const datatype = "array";
       const expectedValue = ["10.0", 10, 10.0];
-      const action = { type: "get", key };
-      storage.getItem.mockReturnValueOnce(JSON.stringify(expectedValue));
+      const action = { type: "get", key, datatype };
+      storage.getItem.mockReturnValueOnce(value);
 
       const actualValue = reducer(storage, action);
 
       expect(storage.getItem).toHaveBeenCalledTimes(1);
-      expect(storage.getItem).toHaveBeenLastCalledWith(expectedKey);
+      expect(storage.getItem).toHaveBeenLastCalledWith(key);
+      expect(actualValue).toEqual(expectedValue);
+    });
+
+    it("should return object value as string for state.getItem with no datatype", () => {
+      const key = "testKey";
+      const value = JSON.stringify({ a: "10.0" });
+      const expectedValue = JSON.stringify({ a: "10.0" });
+      const action = { type: "get", key };
+      storage.getItem.mockReturnValueOnce(value);
+
+      const actualValue = reducer(storage, action);
+
+      expect(storage.getItem).toHaveBeenCalledTimes(1);
+      expect(storage.getItem).toHaveBeenLastCalledWith(key);
+      expect(actualValue).toEqual(expectedValue);
+    });
+
+    it("should return object value as object for state.getItem with datatype object", () => {
+      const key = "testKey";
+      const value = JSON.stringify({ a: "10.0" });
+      const datatype = "object";
+      const expectedValue = { a: "10.0" };
+      const action = { type: "get", key, datatype };
+      storage.getItem.mockReturnValueOnce(value);
+
+      const actualValue = reducer(storage, action);
+
+      expect(storage.getItem).toHaveBeenCalledTimes(1);
+      expect(storage.getItem).toHaveBeenLastCalledWith(key);
       expect(actualValue).toEqual(expectedValue);
     });
 


### PR DESCRIPTION
Implement type specific transformation like toString, toISOString or JSON.stringify for setting into storage and Boolean(value), Date(value), Number(value) or JSON.parse fore getting from storage.